### PR TITLE
Fix by Shahnur — Tax Configuration values were not saved after updating a car rental item.

### DIFF
--- a/admin/settings/MPCRBM_Tax_Settings.php
+++ b/admin/settings/MPCRBM_Tax_Settings.php
@@ -82,12 +82,23 @@
 			}
 
 			public function settings_save( $post_id ) {
+				if (
+					! isset( $_POST['tax_settings_nonce'] ) ||
+					! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['tax_settings_nonce'] ) ), 'save_tax_settings' ) ||
+					( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ||
+					wp_is_post_revision( $post_id ) ||
+					! current_user_can( 'edit_post', $post_id )
+				) {
+					return;
+				}
 				if ( get_post_type( $post_id ) == MPCRBM_Function::get_cpt() ) {
-					// Create and store nonce
-					$nonce = wp_create_nonce( 'settings_save_action' );
-					update_post_meta( $post_id, '_settings_save_nonce', $nonce );
-					$tax_status = MPCRBM_Global_Function::get_submit_info( '_tax_status', 'none' );
-					$tax_class  = MPCRBM_Global_Function::get_submit_info( '_tax_class' );
+					// Fixed by Shahnur — 2026-04-28 11:56 AM (Asia/Dhaka)
+					$allowed_tax_status = array( 'taxable', 'shipping', 'none' );
+					$tax_status         = isset( $_POST['_tax_status'] ) ? sanitize_text_field( wp_unslash( $_POST['_tax_status'] ) ) : 'none';
+					$tax_status         = in_array( $tax_status, $allowed_tax_status, true ) ? $tax_status : 'none';
+					$tax_class          = isset( $_POST['_tax_class'] ) ? sanitize_title( wp_unslash( $_POST['_tax_class'] ) ) : '';
+					$allowed_tax_class  = array_keys( MPCRBM_Global_Function::all_tax_list() );
+					$tax_class          = in_array( $tax_class, $allowed_tax_class, true ) ? $tax_class : '';
 					update_post_meta( $post_id, '_tax_status', $tax_status );
 					update_post_meta( $post_id, '_tax_class', $tax_class );
 				}


### PR DESCRIPTION
Issue: Tax Configuration values were not saved after updating a car rental item.

Resolution: Updated the tax settings save handler to verify the existing tax_settings_nonce, guard autosave/revision/permission cases, and sanitize/validate _tax_status and _tax_class before saving post meta.

Details: The previous handler used MPCRBM_Global_Function::get_submit_info(), which requires _settings_save_nonce, but the Tax Configuration tab renders tax_settings_nonce. Because that nonce mismatch made submitted values resolve empty, the handler overwrote the tax meta with blank values. The hidden WooCommerce product sync remains unchanged and continues to mirror the same posted tax fields after this post meta save.

Validation: Ran php -l on admin/settings/MPCRBM_Tax_Settings.php and git diff --check.