### PR TITLE
Fix broken access control in review edit/delete (Patchstack #32905)

### DIFF
--- a/car-rental-manager.php
+++ b/car-rental-manager.php
@@ -3,7 +3,7 @@
 	 * Plugin Name:       Car Rental Manager – Online Vehicle Booking System
 	 * Plugin URI:        https://wordpress.org/plugins/car-rental-manager
 	 * Description:       A complete car rental solution for WordPress by MagePeople. Manage bookings, vehicles, pricing, and availability with ease.
-	 * Version:           1.3.5
+	 * Version:           1.3.7
 	 * Author:            MagePeople Team
 	 * Author URI:        https://www.mage-people.com/
 	 * License:           GPL v2 or later

--- a/frontend/MPCRBM_Manage_Review.php
+++ b/frontend/MPCRBM_Manage_Review.php
@@ -13,11 +13,14 @@ if (!class_exists('MPCRBM_Manage_Review')) {
             add_action('wp_ajax_mpcrbm_review_save', [ $this, 'mpcrbm_review_save_callback' ] );
             add_action('wp_ajax_nopriv_mpcrbm_review_save', [ $this, 'mpcrbm_review_save_callback' ] );
 
+            // Edit/delete are privileged actions. They must NOT be exposed to
+            // unauthenticated visitors: a guest has get_current_user_id() === 0
+            // and guest reviews are stored with user_id === 0, so a "nopriv"
+            // handler would let anyone edit/delete guest reviews with only the
+            // public frontend nonce (CSRF token, not an authorization check).
             add_action('wp_ajax_mpcrbm_review_delete', [ $this, 'mpcrbm_review_delete_callback' ] );
-            add_action('wp_ajax_nopriv_mpcrbm_review_delete', [ $this, 'mpcrbm_review_delete_callback' ] );
 
             add_action('wp_ajax_mpcrbm_review_edit', [ $this, 'mpcrbm_review_edit_callback' ] );
-            add_action('wp_ajax_nopriv_mpcrbm_review_edit', [ $this, 'mpcrbm_review_edit_callback' ] );
         }
 
         function mpcrbm_review_save_callback() {
@@ -32,11 +35,17 @@ if (!class_exists('MPCRBM_Manage_Review')) {
             $post_id = isset( $_POST['post_id'] ) ? intval( wp_unslash( $_POST['post_id'] ) ) : '';
             $rating  = isset( $_POST['rating'] ) ? intval( wp_unslash( $_POST['rating'] ) ) : '';
 
+            // Record the author's user ID (0 for guests). This is what the
+            // edit/delete ownership check relies on, so a logged-in author can
+            // later manage their own review while guests remain non-owners.
+            $current_user_id = get_current_user_id();
+
             $commentdata = [
                 'comment_post_ID' => $post_id,
                 'comment_author'  => isset( $_POST['author'] ) ? sanitize_text_field( wp_unslash( $_POST['author'] ) ) : '',
                 'comment_author_email' =>  isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '',
                 'comment_content' =>  isset( $_POST['comment'] ) ? sanitize_textarea_field( wp_unslash( $_POST['comment'] ) ) : '',
+                'user_id'         => $current_user_id,
                 'comment_approved' => 1
             ];
 
@@ -62,8 +71,7 @@ if (!class_exists('MPCRBM_Manage_Review')) {
 
             if(!$comment) wp_send_json_error('Comment not found');
 
-            $current_user_id = get_current_user_id();
-            if($current_user_id !== intval($comment->user_id) && !current_user_can('manage_options')){
+            if( ! $this->mpcrbm_user_can_manage_review( $comment ) ){
                 wp_send_json_error('You are not allowed to edit this review');
             }
 
@@ -87,14 +95,42 @@ if (!class_exists('MPCRBM_Manage_Review')) {
             if(!$comment) wp_send_json_error('Comment not found');
 
             // Permission check: author or admin
-            $current_user_id = get_current_user_id();
-            if($current_user_id !== intval($comment->user_id) && !current_user_can('manage_options')){
+            if( ! $this->mpcrbm_user_can_manage_review( $comment ) ){
                 wp_send_json_error('You are not allowed to delete this review');
             }
 
             wp_delete_comment( $comment_id, true );
 
             wp_send_json_success('Review deleted');
+        }
+
+        /**
+         * Authorization gate for editing/deleting a review comment.
+         *
+         * Returns true only when the current request comes from:
+         *  - a comment moderator/administrator (moderate_comments capability), or
+         *  - the logged-in author who actually owns the comment.
+         *
+         * Guests (user_id === 0) can never be owners: a logged-out visitor has
+         * get_current_user_id() === 0, which must NOT be treated as owning the
+         * many guest reviews that are also stored with user_id === 0. The public
+         * frontend nonce only proves the request is same-origin, not who sent it.
+         *
+         * @param WP_Comment $comment Comment object being acted upon.
+         * @return bool
+         */
+        private function mpcrbm_user_can_manage_review( $comment ) {
+
+            // Moderators/admins may always manage reviews.
+            if ( current_user_can( 'moderate_comments' ) ) {
+                return true;
+            }
+
+            $current_user_id = get_current_user_id();
+            $comment_user_id = isset( $comment->user_id ) ? intval( $comment->user_id ) : 0;
+
+            // Must be a logged-in user who owns a comment that has a real owner.
+            return $current_user_id > 0 && $comment_user_id > 0 && $current_user_id === $comment_user_id;
         }
 
     }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: magepeopleteam, hamidxazad, aamahin, sjrubel10
 Author URI : https://mage-people.com
 Tags: Car Rental, Ride Booking, Cab Booking, Car
 Requires at least: 5.6
-Stable tag: 1.3.1
+Stable tag: 1.3.7
 Tested up to: 6.9
 Requires PHP: 7.2
 License: GPLv2 or later
@@ -120,6 +120,11 @@ Yes you can offer extra services along with the car
 
 = Where do I report security bugs found in this plugin? =
 Please report security bugs found in the source code of the Car Rental Manager for WordPress plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/b1431560-8325-44d1-9a15-6f0ccfb485d4). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
+== Changelog ==
+
+= 1.3.7 =
+* Security: Fixed a Broken Access Control vulnerability (Patchstack) in the front-end review handlers. Unauthenticated visitors could edit or delete guest-submitted reviews by supplying a comment ID and the public review nonce. Edit/delete are now restricted to comment moderators and the logged-in review author.
 
 == External Services ==
 


### PR DESCRIPTION
Security: unauthenticated visitors and non-owners could edit/delete reviews via wp_ajax_nopriv_* handlers whose ownership check collapsed under a zero-user-id identity match (CVSS 5.3).

- Unregister nopriv edit/delete AJAX handlers
- Store comment author user_id on save for ownership attribution
- Add mpcrbm_user_can_manage_review(): allow only moderate_comments capability holders or the logged-in author (non-zero id match)

Release: bump plugin Version and Stable tag to 1.3.7, add changelog.