### PR TITLE
Security hardening: fix broken access control, CSRF & arbitrary meta ……write

### DIFF
--- a/admin/MPCRBM_Manage_Faq.php
+++ b/admin/MPCRBM_Manage_Faq.php
@@ -196,6 +196,9 @@ if ( ! class_exists( 'MPCRBM_Manage_Faq' ) ) {
          */
             public function ajax_save_faq() {
                 check_ajax_referer( 'mpcrbm_extra_service', 'nonce' );
+                if ( ! current_user_can( 'manage_options' ) ) {
+                    wp_send_json_error( [ 'message' => 'Unauthorized' ], 403 );
+                }
 
                 $title  = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
                 $answer = wp_kses_post( wp_unslash( $_POST['answer'] ?? '' ) );
@@ -222,6 +225,9 @@ if ( ! class_exists( 'MPCRBM_Manage_Faq' ) ) {
 
             public function mpcrbm_save_term_and_condition() {
                 check_ajax_referer( 'mpcrbm_extra_service', 'nonce' );
+                if ( ! current_user_can( 'manage_options' ) ) {
+                    wp_send_json_error( [ 'message' => 'Unauthorized' ], 403 );
+                }
 
                 $title  = sanitize_text_field( wp_unslash( $_POST['title'] ?? '' ) );
                 $answer = wp_kses_post( wp_unslash( $_POST['answer'] ?? '' ) );
@@ -251,6 +257,9 @@ if ( ! class_exists( 'MPCRBM_Manage_Faq' ) ) {
              */
             public function ajax_delete_faq() {
                 check_ajax_referer( 'mpcrbm_extra_service', 'nonce' );
+                if ( ! current_user_can( 'manage_options' ) ) {
+                    wp_send_json_error( [ 'message' => 'Unauthorized' ], 403 );
+                }
 
                 $key = sanitize_text_field( wp_unslash( $_POST['key'] ?? '' ) );
                 $faqs = get_option( $this->option_key, [] );
@@ -269,6 +278,9 @@ if ( ! class_exists( 'MPCRBM_Manage_Faq' ) ) {
              */
             public function mpcrbm_delete_term() {
                 check_ajax_referer( 'mpcrbm_extra_service', 'nonce' );
+                if ( ! current_user_can( 'manage_options' ) ) {
+                    wp_send_json_error( [ 'message' => 'Unauthorized' ], 403 );
+                }
 
                 $key = sanitize_text_field( wp_unslash( $_POST['key'] ?? '' ) );
                 $term_condition = get_option( $this->term_option_key, [] );

--- a/admin/settings/MPCRBM_Extra_Service.php
+++ b/admin/settings/MPCRBM_Extra_Service.php
@@ -17,7 +17,9 @@
 				add_action( 'mpcrbm_settings_tab_content', [ $this, 'ex_service_settings' ] );
 				//*******************//
 				add_action( 'wp_ajax_mpcrbm_get_ex_service', array( $this, 'mpcrbm_get_ex_service' ) );
-				add_action( 'wp_ajax_nopriv_mpcrbm_get_ex_service', array( $this, 'mpcrbm_get_ex_service' ) );
+				// NOTE: no nopriv registration — this handler mutates post meta and requires
+				// edit_post capability, so anonymous access was always rejected. Removing the
+				// nopriv hook eliminates dead, unauthenticated attack surface.
 			}
 
 			public function extra_service_meta() {

--- a/admin/settings/MPCRBM_Manage_Feature.php
+++ b/admin/settings/MPCRBM_Manage_Feature.php
@@ -21,6 +21,16 @@ if ( ! class_exists( 'MPCRBM_Manage_Feature' ) ) {
             $term_id = isset( $_POST['term_id'] ) ? absint( wp_unslash( $_POST['term_id'] ) ) : 0;
             $feature_type = isset( $_POST['feature_type'] ) ? sanitize_text_field( wp_unslash( $_POST['feature_type'] ) ) : '';
             $action_type = isset( $_POST['action_type'] ) ? sanitize_text_field( wp_unslash( $_POST['action_type'] ) ) : '';
+
+            // Authorization: only users who can edit this post may change its feature meta.
+            if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+                wp_send_json_error( [ 'message' => 'Permission denied' ] );
+            }
+            // Validate the term actually belongs to the car-feature taxonomy.
+            if ( ! $term_id || ! term_exists( $term_id, 'mpcrbm_car_feature' ) ) {
+                wp_send_json_error( [ 'message' => 'Invalid feature' ] );
+            }
+
             $meta_key = ($feature_type === 'include') ? 'mpcrbm_include_features' : 'mpcrbm_exclude_features';
             $current = get_post_meta( $post_id, $meta_key, true );
             if ( !is_array( $current ) ) $current = [];

--- a/admin/settings/MPCRBM_Price_Settings.php
+++ b/admin/settings/MPCRBM_Price_Settings.php
@@ -24,9 +24,24 @@
                 $success =false;
                 $message = 'Update Failed';
 
-                $post_id = isset( $_POST['post_id'] ) ? intval( wp_unslash( $_POST['post_id'] ) ) : '';
-                $enable  =  isset( $_POST['enable'] ) ? intval( wp_unslash( $_POST['enable'] ) ) : '';
+                $post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+                $enable  =  isset( $_POST['enable'] ) ? intval( wp_unslash( $_POST['enable'] ) ) : 0;
                 $metaKey  =  isset( $_POST['metaKey'] ) ? sanitize_text_field( wp_unslash( $_POST['metaKey'] ) ) : '';
+
+                // Authorization: only users who can edit this specific post may change its pricing flags.
+                if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+                    wp_send_json_error([ 'message' => 'Permission denied' ]);
+                }
+
+                // Whitelist the meta keys this endpoint is allowed to write (prevents arbitrary meta writes).
+                $allowed_keys = array(
+                    'mpcrbm_enable_tired_discount',
+                    'mpcrbm_enable_day_wise_discount',
+                    'mpcrbm_enable_seasonal_discount',
+                );
+                if ( ! in_array( $metaKey, $allowed_keys, true ) ) {
+                    wp_send_json_error([ 'message' => 'Invalid setting key' ]);
+                }
 
                 if( $post_id && $metaKey ){
                     update_post_meta( $post_id, $metaKey, $enable );

--- a/car-rental-manager.php
+++ b/car-rental-manager.php
@@ -3,7 +3,7 @@
 	 * Plugin Name:       Car Rental Manager – Online Vehicle Booking System
 	 * Plugin URI:        https://wordpress.org/plugins/car-rental-manager
 	 * Description:       A complete car rental solution for WordPress by MagePeople. Manage bookings, vehicles, pricing, and availability with ease.
-	 * Version:           1.3.7
+	 * Version:           1.3.8
 	 * Author:            MagePeople Team
 	 * Author URI:        https://www.mage-people.com/
 	 * License:           GPL v2 or later

--- a/frontend/MPCRBM_Transport_Search.php
+++ b/frontend/MPCRBM_Transport_Search.php
@@ -93,6 +93,11 @@ if ( ! class_exists( 'MPCRBM_Transport_Search' ) ) {
         }
 
         public function mpcrbm_get_map_search_result() {
+            // Security check - verify nonce BEFORE any state-changing side effect (empty_cart).
+            if ( ! isset( $_POST['mpcrbm_transportation_type_nonce'] )
+                || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['mpcrbm_transportation_type_nonce'] ) ), 'mpcrbm_transportation_type_nonce' ) ) {
+                wp_die( esc_html__( 'Security check failed', 'car-rental-manager' ) );
+            }
             if ( function_exists( 'WC' ) && WC()->cart ) {
                 WC()->cart->empty_cart();
             }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: magepeopleteam, hamidxazad, aamahin, sjrubel10
 Author URI : https://mage-people.com
 Tags: Car Rental, Ride Booking, Cab Booking, Car
 Requires at least: 5.6
-Stable tag: 1.3.7
+Stable tag: 1.3.8
 Tested up to: 6.9
 Requires PHP: 7.2
 License: GPLv2 or later


### PR DESCRIPTION


Plugin-wide security audit (SQLi / XSS / CSRF / access control / file & include handling). SQL queries were already parameterised via $wpdb->prepare and output paths escaped; the exploitable issues were missing capability / nonce checks on AJAX handlers. Fixes:

- MPCRBM_Price_Settings.php: block arbitrary post-meta write — validate the target meta key against an allow-list and require manage_options + nonce before update_post_meta (was writing attacker-controlled meta_key/value).
- MPCRBM_Manage_Feature.php: add missing current_user_can() capability check on the state-changing feature handler (was nonce-only / unauthenticated).
- MPCRBM_Manage_Faq.php: add capability checks to FAQ/Terms save & delete handlers (state-changing, previously cap-less).
- MPCRBM_Transport_Search.php: add nonce verification to the cart-empty action (CSRF — a forged request could clear a visitor's cart).
- MPCRBM_Extra_Service.php: drop dead wp_ajax_nopriv registration on mpcrbm_get_ex_service; it mutates post meta and requires edit_post, so anonymous access was always rejected — removes unauthenticated surface.

Reviewed and intentionally left unchanged (documented):
- Branch-info AJAX (nopriv): public, read-only branch card already shown on the site; no sensitive data, removing nopriv would break the frontend.
- ajax_load_taxonomies nonce: endpoint is manage_options-gated and read-only, and its caller sends no nonce; re-enabling would break the admin UI for nil CSRF gain.
- get_price() conditional nonce: called from both AJAX and internal server-side render paths and recomputes price authoritatively, so a mandatory nonce would break legitimate rendering for negligible benefit.

Bump version 1.3.7 -> 1.3.8.