### PR TITLE
Fix admin UI polish: mobile responsiveness, tab persistence, toggle s…

### DIFF
--- a/admin/MPCRBM_Admin_Shell.php
+++ b/admin/MPCRBM_Admin_Shell.php
@@ -277,8 +277,8 @@
 					// Managers / Global Settings below.
 					$items[] = [
 						'slug'  => 'mpcrbm_locations_manager',
-						'label' => esc_html__( 'Locations', 'car-rental-manager' ),
-						'icon'  => 'fas fa-map-marker-alt',
+						'label' => esc_html__( 'Branch Management', 'car-rental-manager' ),
+						'icon'  => 'fas fa-building',
 						'link'  => $base_url . '&page=mpcrbm_locations_manager',
 					];
 					$items[] = [

--- a/admin/settings/MPCRBM_Multi_Location_Settings.php
+++ b/admin/settings/MPCRBM_Multi_Location_Settings.php
@@ -42,7 +42,7 @@
 						<div class="mpcrbm-info-card-header">
 							<i class="fas fa-map-pin"></i>
 							<div>
-								<h3><?php esc_html_e( 'Multi-Location Settings', 'car-rental-manager' ); ?></h3>
+								<h3><?php esc_html_e( 'Multi-Location Fee', 'car-rental-manager' ); ?></h3>
 								<span class="desc"><?php esc_html_e( 'Allow this vehicle to be rented from multiple pickup and drop-off locations', 'car-rental-manager' ); ?></span>
 							</div>
 							<?php MPCRBM_Custom_Layout::switch_button( 'mpcrbm_multi_location_enabled', $enabled_checked ); ?>

--- a/admin/settings/MPCRBM_Tax_Settings.php
+++ b/admin/settings/MPCRBM_Tax_Settings.php
@@ -136,7 +136,7 @@
                             </div>
 							<?php if ( $total_count > 0 ) : ?>
                                 <div class="mpcrbm-faq-live-pill">
-                                    <span class="mpcrbm-faq-live-switch"></span>
+                                    <span class="mpcrbm-faq-live-switch<?php echo $selected_count > 0 ? '' : ' is-off'; ?>" id="mpcrbm_rr_live_switch"></span>
                                     <span>
                                         <span id="mpcrbm_rr_selected_count"><?php echo esc_html( $selected_count ); ?></span>
 										<?php esc_html_e( 'of', 'car-rental-manager' ); ?>
@@ -176,7 +176,9 @@
                                 var $grid = $('#mpcrbm_rr_grid');
                                 $grid.on('change', '.mpcrbm-rr-check-input', function () {
                                     $(this).closest('.mpcrbm-rr-item').toggleClass('is-selected', this.checked);
-                                    $('#mpcrbm_rr_selected_count').text($grid.find('.mpcrbm-rr-check-input:checked').length);
+                                    var checkedCount = $grid.find('.mpcrbm-rr-check-input:checked').length;
+                                    $('#mpcrbm_rr_selected_count').text(checkedCount);
+                                    $('#mpcrbm_rr_live_switch').toggleClass('is-off', checkedCount === 0);
                                 });
                             });
                             </script>

--- a/assets/admin/mpcrbm-shell.css
+++ b/assets/admin/mpcrbm-shell.css
@@ -16,7 +16,7 @@
    (dashboard pages + the car edit screen) — not applied anywhere else in
    wp-admin. */
 html.wp-toolbar {
-	padding-top: 10px;
+	padding-top: 0px;
 }
 
 body.mpcrbm-admin {
@@ -1743,31 +1743,34 @@ body.mpcrbm-admin .mpcrbm-shell-body a.mpcrbm_action_btn:hover {
 	background-color: var(--mpcrbm-shell-primary, #1d7bff);
 }
 
-/* Loading state on a round-switch toggle while its AJAX save is in flight
-   (mpcrbm_admin.js's ".mpcrbm_switch_checkbox" click handler) — shown BEFORE
-   the corresponding "#<id>_holder" card body reveals/hides, since that only
-   happens once the request's success callback actually runs. */
-.roundSwitchLabel.mpcrbm-switch-loading {
+/* Loading state on a card body while its toggle's AJAX save is in flight
+   (mpcrbm_admin.js's ".mpcrbm_switch_checkbox" click handler) — the spinner
+   is centered on the "#<id>_holder" content panel itself (not the switch),
+   since that's the area about to expand/collapse once the request's success
+   callback reveals/hides it. Content is hidden rather than removed so the
+   panel keeps its layout/height while loading. */
+.mpcrbm-info-card-body.mpcrbm-content-loading {
 	position: relative;
-	pointer-events: none;
+	min-height: 60px;
 }
 
-.roundSwitchLabel.mpcrbm-switch-loading .roundSwitch {
-	opacity: .5;
+.mpcrbm-info-card-body.mpcrbm-content-loading > * {
+	visibility: hidden;
 }
 
-.roundSwitchLabel.mpcrbm-switch-loading::after {
+.mpcrbm-info-card-body.mpcrbm-content-loading::after {
 	content: "";
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	width: 14px;
-	height: 14px;
-	margin: -7px 0 0 -7px;
-	border: 2px solid rgba(0, 0, 0, .15);
+	width: 22px;
+	height: 22px;
+	margin: -11px 0 0 -11px;
+	border: 3px solid rgba(0, 0, 0, .15);
 	border-top-color: var(--mpcrbm-shell-primary, #1d7bff);
 	border-radius: 50%;
 	animation: mpcrbm-switch-spin .6s linear infinite;
+	visibility: visible;
 }
 
 @keyframes mpcrbm-switch-spin {
@@ -1784,6 +1787,28 @@ body.mpcrbm-admin .mpcrbm-shell-body a.mpcrbm_action_btn:hover {
 		width: 100%;
 		margin-top: 16px;
 	}
+
+	/* Tab nav bar (General Info / Pricing / .../ Advanced): the base rule's
+	   "flex-flow: row wrap" (~line 1357) wraps 9 chip-style tabs into several
+	   ragged, sticky-pinned rows on narrow screens — eating vertical space and
+	   squishing long labels like "Operation Area & Date Time". Below this
+	   width it becomes a single horizontally-scrollable row instead, same
+	   convention as any other overflowing tab/pill strip. */
+	#mpcrbm_meta_box_panel .mpcrbm_settings .tabLists {
+		flex-wrap: nowrap;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: thin;
+		padding: 8px 10px;
+		gap: 4px;
+	}
+
+	#mpcrbm_meta_box_panel .mpcrbm_settings .tabLists li[data-tabs-target] {
+		flex: 0 0 auto;
+		white-space: nowrap;
+		padding: 8px 12px;
+		font-size: 13px;
+	}
 }
 
 /* ==========================================================================
@@ -1796,8 +1821,17 @@ body.mpcrbm-admin .mpcrbm-shell-body a.mpcrbm_action_btn:hover {
    (only this card, only the Car edit screen), never the bare utility classes.
    ========================================================================== */
 
+/* Each row's inputs carry a 100px min-width (further down), so the row as a
+   whole doesn't fit narrow/mobile viewports — scroll the table horizontally
+   within its own box instead of letting it force the whole admin page wider. */
+.mpcrbm_extra_service_area {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+}
+
 .mpcrbm_extra_service_area table {
 	width: 100%;
+	min-width: 560px;
 	border-collapse: separate;
 	border-spacing: 0;
 	border: 1px solid var(--mpcrbm-shell-border, #e7e7ea);
@@ -2605,6 +2639,17 @@ body.mpcrbm-admin.post-new-php #submitdiv .submitdelete {
 
 #mpcrbm_meta_box_panel .mpcrbm_settings .mpcrbm-info-card-body {
 	padding: 18px 20px;
+	transition: opacity .35s ease;
+}
+
+/* Paired with the "mpcrbm-fade-in" class toggled in mpcrbm_admin.js's
+   ".mpcrbm_switch_checkbox" success handler: the class is applied right
+   before slideDown() starts (so the panel opens at opacity:0) and removed a
+   frame later, letting this transition fade it in while the height is still
+   animating open — a plain slideDown alone snaps the content in at full
+   opacity as soon as there's any height to show. */
+#mpcrbm_meta_box_panel .mpcrbm_settings .mpcrbm-info-card-body.mpcrbm-fade-in {
+	opacity: 0;
 }
 
 #mpcrbm_meta_box_panel .mpcrbm_settings .tabsContent .tabsItem .mpcrbm-info-grid {
@@ -3236,6 +3281,7 @@ input.formControl.mpcrbm-list-search {
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
+	flex-wrap: wrap;
 	gap: 24px;
 	padding-bottom: 18px;
 	margin-bottom: 18px;

--- a/assets/admin/mpcrbm_admin.css
+++ b/assets/admin/mpcrbm_admin.css
@@ -111,7 +111,6 @@ div.mpcrbm_faq_all_question_box h3,div.mpcrbm_selected_faq_question_box  h3{
     padding: 24px;
     margin-bottom: 24px;
     transition: transform 0.2s, box-shadow 0.2s;
-    width: 82% !important;
 }
 
 #mpcrbm_meta_box_panel .mpcrbm_settings .tabsContent .tabsItem > h2 {

--- a/assets/admin/mpcrbm_admin.js
+++ b/assets/admin/mpcrbm_admin.js
@@ -412,17 +412,22 @@
 			let post_id = $('[name="mpcrbm_post_id"]').val();
 			let metaKey  = $checkbox.attr('id');
 			let containerId =metaKey+'_holder';
+			let $container = $('#' + containerId);
 
 			var heading = $checkbox.closest('.mpcrbm-section').find('.mpcrbm-heading');
 
-			// Visible loading state on the switch itself while the AJAX call is
-			// in flight, so there's feedback right away instead of the card
-			// body just silently sitting there until the request finishes —
-			// it's this callback's success handler (below), not the click
-			// itself, that actually reveals/hides #<metaKey>_holder.
-			let $switchLabel = $checkbox.closest('.roundSwitchLabel');
+			// Visible loading state on the card body itself (centered spinner)
+			// while the AJAX call is in flight, so feedback shows up where the
+			// content is about to expand/collapse rather than on the tiny
+			// switch. When turning a section on, its holder starts out
+			// display:none, so it's revealed right away in the loading state
+			// (content hidden, spinner centered) instead of waiting for the
+			// success handler below to reveal/hide it.
 			$checkbox.prop('disabled', true);
-			$switchLabel.addClass('mpcrbm-switch-loading');
+			if ( checked === 1 ) {
+				$container.show();
+			}
+			$container.addClass('mpcrbm-content-loading');
 
 			$.ajax({
 				type: 'POST',
@@ -439,12 +444,25 @@
 				},
 				success: function(response) {
 
+					$container.removeClass('mpcrbm-content-loading');
+
 					if( response.data.message ){
 						if( checked === 1 ){
-							$("#"+containerId).slideDown(300);
+							// Fade the content in while it slides open (instead of a
+							// flat height-only slide) so it reads as an easing
+							// reveal rather than content snapping into place —
+							// "mpcrbm-fade-in" (opacity:0, see mpcrbm-shell.css)
+							// is dropped a frame after slideDown starts so the CSS
+							// opacity transition runs alongside the slide.
+							$container.hide().addClass('mpcrbm-fade-in').slideDown(400, 'swing');
+							requestAnimationFrame(function() {
+								requestAnimationFrame(function() {
+									$container.removeClass('mpcrbm-fade-in');
+								});
+							});
 							heading.addClass('mpcrbm_toggle_class');
 						}else{
-							$("#"+containerId).slideUp(300);
+							$container.slideUp(280, 'swing');
 							heading.removeClass('mpcrbm_toggle_class');
 						}
 					}else{
@@ -456,11 +474,14 @@
 					// leaving it checked/unchecked out of sync with the saved
 					// (unsaved) meta value.
 					$checkbox.prop('checked', checked !== 1);
+					$container.removeClass('mpcrbm-content-loading');
+					if ( checked === 1 ) {
+						$container.hide();
+					}
 					alert('Something went wrong while saving this setting. Please try again.');
 				},
 				complete: function() {
 					$checkbox.prop('disabled', false);
-					$switchLabel.removeClass('mpcrbm-switch-loading');
 				}
 			});
 		});

--- a/mp_global/assets/mp_style/mpcrbm_global.js
+++ b/mp_global/assets/mp_style/mpcrbm_global.js
@@ -388,6 +388,14 @@ function mpcrbm_sticky_management() {
 //============================================================================Tabs================//
 (function ($) {
     "use strict";
+    // Key the remembered tab per-post (and per ".mpcrbm_tabs" block, in case a
+    // page ever renders more than one) so re-opening a different post doesn't
+    // restore a tab left active on another one. Returns null on the "Add New"
+    // screen (no #post_ID yet), where there's nothing meaningful to persist.
+    function mpcrbm_active_tab_storage_key(tabsIndex) {
+        let postId = $('#post_ID').val();
+        return postId ? 'mpcrbm_active_tab_' + postId + '_' + tabsIndex : null;
+    }
     function active_next_tab(parent, targetTab) {
         parent.height(parent.height());
         let tabsContent = parent.find('.tabsContentNext:first');
@@ -455,9 +463,12 @@ function mpcrbm_sticky_management() {
         active_next_tab(parent, targetTab);
     });
     $(document).ready(function () {
-        $('.mpcrbm .mpcrbm_tabs').each(function () {
+        $('.mpcrbm .mpcrbm_tabs').each(function (tabsIndex) {
             let tabLists = $(this).find('.tabLists:first');
-            let activeTab = tabLists.find('[data-tabs-target].active');
+            let storageKey = mpcrbm_active_tab_storage_key(tabsIndex);
+            let savedTarget = storageKey ? window.localStorage.getItem(storageKey) : null;
+            let savedTab = savedTarget ? tabLists.find('[data-tabs-target="' + savedTarget + '"]') : $();
+            let activeTab = savedTab.length > 0 ? savedTab : tabLists.find('[data-tabs-target].active');
             let targetTab = activeTab.length > 0 ? activeTab : tabLists.find('[data-tabs-target]').first();
             targetTab.trigger('click');
         });
@@ -475,6 +486,11 @@ function mpcrbm_sticky_management() {
         if (!$(this).hasClass('active')) {
             let tabsTarget = $(this).data('tabs-target');
             let parent = $(this).closest('.mpcrbm_tabs');
+            let tabsIndex = $('.mpcrbm .mpcrbm_tabs').index(parent);
+            let storageKey = mpcrbm_active_tab_storage_key(tabsIndex);
+            if (storageKey) {
+                window.localStorage.setItem(storageKey, tabsTarget);
+            }
             parent.height(parent.height());
             let tabLists = $(this).closest('.tabLists');
             let tabsContent = parent.find('.tabsContent:first');


### PR DESCRIPTION
…pinner/animation, and labels

- Center the toggle-loading spinner on the collapsing content panel instead of the switch, and ease the slide-open animation with a synced fade
- Persist the active settings tab across page reloads via localStorage, keyed per post
- Fix mobile responsiveness: tab bar scrolls horizontally instead of wrapping, Extra Service Options table scrolls instead of overflowing the page, and remove a legacy !important width that broke every card panel below 900px
- Add flex-wrap to the shared FAQ/Term & Condition/Related Rental toolbar so actions wrap instead of getting clipped
- Sync the Related Rental "live switch" indicator with actual selection count
- Rename "Multi-Location Settings" card to "Multi-Location Fee" and "Locations" sidebar nav item to "Branch Management" (fa-building icon)